### PR TITLE
Fix issue with apps that invoke Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ $ $EDITOR ~/.gnupg/gpg.conf
 # Add line: default-key E870EE00
 ```
 
+## Optional: Fix for Git UIs
+
+If you use a UI such as Git Tower or Github Desktop, you may need to configure git to point to the specific gpg executable:
+```sh
+git config --global gpg.program $(which gpg)
+```
+
 ## Optional: Disable TTY 
 If you have problems with making autosigned commits from IDE or other software add no-tty config
 ```sh


### PR DESCRIPTION
If git's `gpg.program` is not configured, and `commit.gpgsign` is set, then when `git` is invoked outside of a terminal session, `gpg` may not found. This fixes it by configuring git to use a specific gpg executable.

I found this issue on macOS Sierra with Tower, and found [the answer here](https://github.com/isaacs/github/issues/675#issuecomment-219521841).