### PR TITLE
Keybase app installation through `brew cask`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Although this guide was written for macOS, most commands should work in other op
 ## Requirements
 
 ```sh
-$ brew install gpg keybase
+$ brew install gpg
+$ brew cask install keybase
 ```
 
 You should already have an account with Keybase and be signed in locally using `$ keybase login`. In case you need to set up a new device first, follow the instructions provided by the keybase command during login.


### PR DESCRIPTION
`brew install keybase` no longer works one needs to go through `brew cask`