### PR TITLE
force print gpg keyid

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ keybase pgp gen --multi
 ## Set up Git to sign all commits
 
 ```sh
-$ gpg --list-secret-keys
+$ gpg --list-secret-keys --keyid-format LONG
 # /Users/pstadler/.gnupg/secring.gpg
 # ----------------------------------
 # sec   4096R/E870EE00 2016-04-06 [expires: 2032-04-02]


### PR DESCRIPTION
When i generated my key, the ID wasn't print,
when i listed my key : 
```
$ gpg --list-key    # same for gpg --list-secret-key
pub   rsa4096 2017-09-08 [SC] [expires: 2033-09-04]
      XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
uid           [ unknown] Albert Le Batteux <albert.lebatteux@gmail.com>
sub   rsa4096 2017-09-08 [E] [expires: 2033-09-04]
```

For those having this issue, you need to add ` gpg --keyid-format long --list-key`.

As github explain here : https://help.github.com/articles/telling-git-about-your-gpg-key/
