### PR TITLE
Additional steps to fix "gpg failed to sign the data" errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ $ git commit -m "My commit"
 
 You can run `echo "test" | gpg --clearsign` to find the underlying issue.
 
+If the above succeeds without error, then there is likely a configuration problem that is preventing git from selecting or using the secret key.  Confirm that your gitconfig `user.email` matches the secret key that you are using for signing.
+
 ## Optional: Set as default GPG key
 
 ```sh


### PR DESCRIPTION
`user.email` gitconfig must match secret key used for signing.

Let me know if more clarification and/or shell commands are needed 😺