### PR TITLE
Adding an instruction in pinentry section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ $ $EDITOR ~/.gnupg/gpg-agent.conf
 pinentry-program /usr/local/bin/pinentry-mac
 ```
 
+It may be needed to restart the agent : 
+
+```sh
+# it will start back on the next use
+$ gpgconf --kill gpg-agent
+```
+
+
 Now `git commit -S`, it will ask your password and you can save it to macOS
 keychain.
 


### PR DESCRIPTION
The pinentry window never spawned until I did that.
Solution found here : https://apple.stackexchange.com/questions/236758/how-to-use-gui-pinentry-program-for-gpg