### PR TITLE
Add Apple silicon brew path to pinentry-mac for GPG agent config

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ Set up the agent:
 
 ```sh
 $ $EDITOR ~/.gnupg/gpg-agent.conf
-# Paste this line:
+# Paste this line for Apple silicon:
+pinentry-program /opt/homebrew/bin/pinentry-mac
+# For Intel-based Macs, paste this line instead:
 pinentry-program /usr/local/bin/pinentry-mac
 ```
 


### PR DESCRIPTION
On Apple silicon, the `/usr/local...` path triggers a terminal-based password entry field with no option to save to the macOS keychain. Using the newer path triggers the UI pictured below, allowing you to save your key's password to keychain and not re-enter every time the password cache expires.